### PR TITLE
fix FilledCavity.check_tags

### DIFF
--- a/src/cavity.rs
+++ b/src/cavity.rs
@@ -354,7 +354,7 @@ impl<'a, const D: usize, E: Elem, M: Metric<D>> FilledCavity<'a, D, E, M> {
 
         let mut faces = FxHashMap::with_hasher(BuildHasherDefault::default());
 
-        // Build the cavity internal faces
+        // Build the cavity internal & boundary faces
         for (e, mut f) in self.elems_and_faces() {
             let vtags = e.iter().map(|i| self.cavity.tags[*i as usize]);
             let etag = topo.elem_tag(vtags).unwrap();
@@ -393,19 +393,22 @@ impl<'a, const D: usize, E: Elem, M: Metric<D>> FilledCavity<'a, D, E, M> {
 
                     if parents.len() == 1 {
                         // a boundary face shound belong to only one element
-                        return *n == 1;
-                    }
-                    // otherwise, check that all parent tags are present
-                    for (e, _f) in self.elems_and_faces() {
-                        let fj_in_e = fj.iter().all(|i| vertex_in_elem(&e, *i));
-                        if fj_in_e {
-                            let vtags = e.iter().map(|i| self.cavity.tags[*i as usize]);
-                            let etag = topo.elem_tag(vtags).unwrap();
-                            let _ok = parents.remove(&etag.1);
+                        if *n != 1 {
+                            return false;
                         }
-                    }
-                    if !parents.is_empty() {
-                        return false;
+                    } else {
+                        // otherwise, check that all parent tags are present
+                        for (e, _f) in self.elems_and_faces() {
+                            let fj_in_e = fj.iter().all(|i| vertex_in_elem(&e, *i));
+                            if fj_in_e {
+                                let vtags = e.iter().map(|i| self.cavity.tags[*i as usize]);
+                                let etag = topo.elem_tag(vtags).unwrap();
+                                let _ok = parents.remove(&etag.1);
+                            }
+                        }
+                        if !parents.is_empty() {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/cavity.rs
+++ b/src/cavity.rs
@@ -443,10 +443,12 @@ impl<'a, const D: usize, E: Elem, M: Metric<D>> FilledCavity<'a, D, E, M> {
                 for f in self.faces() {
                     for i_edge in 0..E::Face::N_EDGES {
                         let e = f.edge(i_edge);
-                        let new_f = [self.id.unwrap(), e[0], e[1]];
-                        let vtags = f.iter().map(|i| self.cavity.tags[*i as usize]);
+                        let new_f = E::Face::from_slice(&[self.id.unwrap(), e[0], e[1]]);
+                        let vtags = new_f.iter().map(|i| self.cavity.tags[*i as usize]);
                         let ftag = topo.elem_tag(vtags).unwrap();
-                        if ftag.0 == E::Face::DIM as Dim {
+                        let topo_node = topo.get(ftag).unwrap();
+                        let parents = &topo_node.parents;
+                        if ftag.0 == E::Face::DIM as Dim && parents.len() == 1 {
                             // boundary face.
                             let p0 = &self.cavity.points[new_f[0] as usize];
                             let p1 = &self.cavity.points[new_f[1] as usize];

--- a/src/remesher.rs
+++ b/src/remesher.rs
@@ -280,9 +280,9 @@ impl<const D: usize, E: Elem, M: Metric<D>, G: Geometry<D>> Remesher<D, E, M, G>
                     *i != i_elem && f.iter().all(|j| vertex_in_elem(&other, *j))
                 });
                 if let Some(other) = els.next() {
-                    // At least 2 elements
+                    // At least 3 elements
                     if els.next().is_some() {
-                        return Err(Error::from("A face belongs to o more than 2 elements"));
+                        return Err(Error::from("A face belongs to more than 2 elements"));
                     }
                     let other = self.elems.get(other).unwrap().el;
                     let vtags = other.iter().map(|i| self.verts.get(i).unwrap().tag);
@@ -296,6 +296,10 @@ impl<const D: usize, E: Elem, M: Metric<D>, G: Geometry<D>> Remesher<D, E, M, G>
                             "A face belonging to 2 element with the same tags is not tagged correctly",
                         ));
                     }
+                } else if ftag.0 != E::Face::DIM as Dim {
+                    return Err(Error::from(
+                        "A face belonging to 1 element is not tagged correctly",
+                    ));
                 }
             }
         }


### PR DESCRIPTION
two bug fixes related to boundary faces:
 - boundary faces could be tagged on lines
 - normal checks were wrong which in addition to low quality meshes could also lead to internal faces tagged as boundary