### PR TITLE
Modification of the computation of element tags in Remesher

### DIFF
--- a/src/test_meshes.rs
+++ b/src/test_meshes.rs
@@ -6,6 +6,8 @@ use std::fs::File;
 use std::io::Write;
 
 /// Build a 2d mesh of a square with 2 triangles tagged differently
+/// WARNING: the mesh tags are not valid as the diagonal (0, 2) is between
+/// two different element tags not is not tagged
 #[must_use]
 pub fn test_mesh_2d() -> SimplexMesh<2, Triangle> {
     let coords = vec![

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -650,17 +650,6 @@ mod tests {
         assert_eq!(topo.entities[1].len(), 12);
         assert_eq!(topo.entities[2].len(), 6);
         assert_eq!(topo.entities[3].len(), 1);
-
-        // assert_eq!(
-        //     vtags[0],
-        //     topo.get_from_parents(0, vec![1, 4, 5]).unwrap().tag
-        // );
-        // assert_eq!(vtags[1], topo.get_from_parents(0, vec![1, 2]).unwrap().tag);
-        // assert_eq!(
-        //     vtags[2],
-        //     topo.get_from_parents(0, vec![2, 3, 5]).unwrap().tag
-        // );
-        // assert_eq!(vtags[3], topo.get_from_parents(0, vec![3, 4]).unwrap().tag);
     }
 
     #[test]


### PR DESCRIPTION
In order to avoid creating elements with poor quality in order in order to be able to compute the tag of all elements based of the tags of the vertices, `elem_tag` is modified.