### PR TITLE
fix(deps): bump pyo3 to address security issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.4.0"
 
 [workspace.dependencies]
 nalgebra = "0.35.0"
-log = "0.4.30"
+log = "0.4.33"
 libm = "0.2.16"
 rand = "0.10.1"
 rayon = "1.12.0"

--- a/pytucanos/Cargo.toml
+++ b/pytucanos/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 [dependencies]
 log.workspace = true
 tucanos = { path="../tucanos" }
-numpy = "0.28.0"
-pyo3 = { version = "0.28.3", features = ["extension-module", "multiple-pymethods"] }
-pyo3-log = "0.13.3"
+numpy = "0.29.0"
+pyo3 = { version = "0.29.0", features = ["extension-module", "multiple-pymethods"] }
+pyo3-log = "0.13.4"
 rayon.workspace = true
 affinity = "0.1.2"
 tmesh = { path = "../tmesh" }


### PR DESCRIPTION
Bumps pyo3 to 0.29.0 to patch GHSA-36hh-v3qg-5jq4 (out-of-bounds read) and GHSA-chgr-c6px-7xpp (missing Sync bound).

Also updates workspace dependencies (log, numpy, pyo3-log).