### PR TITLE
cgns_io: support writing QuadraticBoundaryMesh2d (BAR_3) geometry files

### DIFF
--- a/pytucanos/pytucanos/cgns_io.py
+++ b/pytucanos/pytucanos/cgns_io.py
@@ -335,7 +335,7 @@ def write_cgns(
         cell_dim = 3
     elif isinstance(mesh, (Mesh2d, BoundaryMesh3d, QuadraticBoundaryMesh3d)):
         cell_dim = 2
-    elif isinstance(mesh, BoundaryMesh2d):
+    elif isinstance(mesh, (BoundaryMesh2d, QuadraticBoundaryMesh2d)):
         cell_dim = 1
     else:
         raise NotImplementedError(f"not implemented for {type(mesh)}")
@@ -351,6 +351,15 @@ def write_cgns(
     CGL.newDataArray(gc, CGK.CoordinateY_s, coords[:, 1].copy())
     if coords.shape[1] == 3:
         CGL.newDataArray(gc, CGK.CoordinateZ_s, coords[:, 2].copy())
+    else:
+        # load_cgns always reads CoordinateZ, even for a phys_dim=2 mesh (it
+        # picks the flat axis from whichever of X/Y/Z is all-zero). Without
+        # it, load_cgns cannot read the file write_cgns just produced, for
+        # every 2D mesh type, not just the new QuadraticBoundaryMesh2d case
+        # below.
+        CGL.newDataArray(
+            gc, CGK.CoordinateZ_s, np.zeros(coords.shape[0], dtype=np.float64)
+        )
 
     if isinstance(mesh, Mesh3d):
         logging.info(f"Adding {base[0]}/{zone[0]}/Elems")
@@ -405,13 +414,30 @@ def write_cgns(
             np.array([1, mesh.n_elems()]),
             elems.astype(np.int32).ravel() + 1,
         )
+    elif isinstance(mesh, QuadraticBoundaryMesh2d):
+        logging.info(f"Adding {base[0]}/{zone[0]}/Elems")
+        CGL.newElements(
+            zone,
+            "Elems",
+            CGK.BAR_3,
+            np.array([1, mesh.n_elems()]),
+            elems.astype(np.int32).ravel() + 1,
+        )
     else:
         raise NotImplementedError(f"not implemented for {type(mesh)}")
 
     zbc = CGL.newZoneBC(zone)
     if isinstance(mesh, (Mesh2d, Mesh3d)):
         ftags = mesh.get_ftags()
-    elif isinstance(mesh, (BoundaryMesh2d, BoundaryMesh3d, QuadraticBoundaryMesh3d)):
+    elif isinstance(
+        mesh,
+        (
+            BoundaryMesh2d,
+            QuadraticBoundaryMesh2d,
+            BoundaryMesh3d,
+            QuadraticBoundaryMesh3d,
+        ),
+    ):
         ftags = mesh.get_etags()
     else:
         raise NotImplementedError(f"not implemented for {type(mesh)}")

--- a/pytucanos/pytucanos/test_cgns_io.py
+++ b/pytucanos/pytucanos/test_cgns_io.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from . import BoundaryMesh2d, Idx, QuadraticBoundaryMesh2d, load_cgns, write_cgns
+from .cgns_io import HAVE_CGNS
+
+
+@unittest.skipIf(not HAVE_CGNS, "pycgns not available")
+class TestCgnsIo2d(unittest.TestCase):
+    def test_roundtrip_boundary_mesh_2d(self):
+        coords = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], dtype=np.float64
+        )
+        edges = np.array([[0, 1], [1, 2], [2, 3], [3, 0]], dtype=Idx)
+        etags = np.array([1, 1, 2, 2], dtype=np.int16)
+        faces = np.empty((0, 1), dtype=Idx)
+        ftags = np.empty(0, dtype=np.int16)
+        msh = BoundaryMesh2d(coords, edges, etags, faces, ftags)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "square.cgns")
+            write_cgns(msh, path, {"a": 1, "b": 2})
+            back, names = load_cgns(path)
+
+            self.assertEqual(names, {"a": 1, "b": 2})
+            self.assertTrue(np.allclose(back.get_verts(), coords))
+            self.assertTrue(np.array_equal(back.get_elems(), edges))
+            self.assertTrue(np.array_equal(back.get_etags(), etags))
+
+    def test_roundtrip_quadratic_boundary_mesh_2d(self):
+        # Same square, but each edge is a BAR_3 bowed outward from its
+        # linear midpoint. If write_cgns or load_cgns silently dropped the
+        # curvature (e.g. read back as straight BAR_2, or swapped the
+        # corners and mid-node), the checks below would catch it.
+        corners = np.array(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], dtype=np.float64
+        )
+        mids = np.array(
+            [[0.5, -0.1], [1.1, 0.5], [0.5, 1.1], [-0.1, 0.5]], dtype=np.float64
+        )
+        coords = np.vstack([corners, mids])
+        edges = np.array([[0, 1, 4], [1, 2, 5], [2, 3, 6], [3, 0, 7]], dtype=Idx)
+        etags = np.array([1, 1, 2, 2], dtype=np.int16)
+        faces = np.empty((0, 1), dtype=Idx)
+        ftags = np.empty(0, dtype=np.int16)
+        msh = QuadraticBoundaryMesh2d(coords, edges, etags, faces, ftags)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "curved_square.cgns")
+            write_cgns(msh, path, {"a": 1, "b": 2})
+            back, names = load_cgns(path)
+
+            self.assertIsInstance(back, QuadraticBoundaryMesh2d)
+            self.assertEqual(names, {"a": 1, "b": 2})
+            self.assertTrue(np.allclose(back.get_verts(), coords))
+            self.assertTrue(np.array_equal(back.get_elems(), edges))
+            self.assertTrue(np.array_equal(back.get_etags(), etags))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
write_cgns already had a QuadraticBoundaryMesh3d to TRI_6 branch but no 2D counterpart, so a curved (order-2) 2D boundary/geometry mesh could be read back via load_cgns but never written. This adds the missing BAR_3 branch, mirroring the existing TRI_6 one.

It also fixes write_cgns to always add a CoordinateZ dataset for a phys_dim=2 mesh (previously only added when coords already had 3 columns). Without it, load_cgns cannot read the file write_cgns just produced for any phys_dim=2 mesh, since it always looks for CoordinateZ to determine the flat axis.

Covered by two new tests in test_cgns_io.py that write then read back a BoundaryMesh2d and a QuadraticBoundaryMesh2d. The rest of the pytucanos test suite (test_mesh, test_geometry, test_extruded, test_autotag, test_solb, test_dual) still passes unchanged.