### PR TITLE
pytucanos: reject F-ordered arrays instead of silently misreading them

### DIFF
--- a/pytucanos/pytucanos/test_mesh.py
+++ b/pytucanos/pytucanos/test_mesh.py
@@ -131,6 +131,23 @@ class TestMeshes(unittest.TestCase):
         self.assertTrue(np.allclose(msh.get_faces(), faces))
         self.assertTrue(np.allclose(msh.get_ftags(), ftags))
 
+    def test_init_f_order_fail(self):
+        # F-ordered (column-major) arrays used to be accepted and read as if
+        # they were C-ordered, silently scrambling the connectivity (e.g.
+        # elems[:, [1, 0, 2]] returns an F-ordered copy). They must now be
+        # rejected with a clear error.
+        coords, elems, etags, faces, ftags = get_square()
+
+        flipped = elems[:, [1, 0, 2]]
+        self.assertFalse(flipped.flags["C_CONTIGUOUS"])
+        with self.assertRaises(ValueError):
+            _msh = Mesh2d(coords, flipped, etags, faces, ftags)
+        with self.assertRaises(ValueError):
+            _msh = Mesh2d(np.asfortranarray(coords), elems, etags, faces, ftags)
+
+        msh = Mesh2d(coords, np.ascontiguousarray(flipped), etags, faces, ftags)
+        self.assertTrue(np.array_equal(msh.get_elems(), flipped))
+
     def test_meshb_2d(self):
         coords, elems, etags, faces, ftags = get_square()
         msh = Mesh2d(coords, elems, etags, faces, ftags)

--- a/pytucanos/src/extruded.rs
+++ b/pytucanos/src/extruded.rs
@@ -63,7 +63,7 @@ impl PyExtrudedMesh2d {
             return Err(PyValueError::new_err("Invalid dimension 0 for quad_tags"));
         }
 
-        let coords = coords.as_slice()?;
+        let coords = crate::as_c_slice(&coords)?;
         let coords = coords
             .chunks(3)
             .map(|p| {
@@ -73,19 +73,19 @@ impl PyExtrudedMesh2d {
             })
             .collect();
 
-        let prisms = prisms.as_slice()?;
+        let prisms = crate::as_c_slice(&prisms)?;
         let prisms = prisms
             .chunks(6)
             .map(|x| Prism::<Idx>::from_iter(x.iter().copied().map(|x| x.try_into().unwrap())))
             .collect();
 
-        let tris = tris.as_slice()?;
+        let tris = crate::as_c_slice(&tris)?;
         let tris = tris
             .chunks(3)
             .map(|x| Triangle::<Idx>::from_iter(x.iter().copied().map(|x| x.try_into().unwrap())))
             .collect();
 
-        let quads = quads.as_slice()?;
+        let quads = crate::as_c_slice(&quads)?;
         let quads = quads
             .chunks(4)
             .map(|x| Quadrangle::<Idx>::from_iter(x.iter().copied().map(|x| x.try_into().unwrap())))

--- a/pytucanos/src/lib.rs
+++ b/pytucanos/src/lib.rs
@@ -7,10 +7,13 @@ mod metric;
 mod parallel;
 mod poly;
 mod remesher;
-use numpy::{PyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1};
+use numpy::{
+    PyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray, PyReadonlyArray1,
+    PyUntypedArrayMethods, ndarray::Dimension,
+};
 use pyo3::{
     Bound, PyResult, Python,
-    exceptions::PyRuntimeError,
+    exceptions::{PyRuntimeError, PyValueError},
     pyfunction, pymodule,
     types::{PyModule, PyModuleMethods},
     wrap_pyfunction,
@@ -20,6 +23,24 @@ use pyo3::{
 pub type Idx = u32;
 #[cfg(not(feature = "32bit-ints"))]
 pub type Idx = usize;
+
+/// Get the flat data slice of a numpy array, requiring C (row-major) order.
+///
+/// `as_slice` alone accepts any contiguous layout, including Fortran order
+/// (e.g. `arr[:, [1, 0, 2]]` returns an F-ordered copy), but the flat buffer
+/// of an F-ordered array is the transpose of what the row-major consumers of
+/// this crate expect, so the values would be silently scrambled. 1D
+/// contiguous arrays carry both contiguity flags and always pass.
+pub(crate) fn as_c_slice<'a, T: numpy::Element, D: Dimension>(
+    arr: &'a PyReadonlyArray<'_, T, D>,
+) -> PyResult<&'a [T]> {
+    if !arr.is_c_contiguous() {
+        return Err(PyValueError::new_err(
+            "array is not C-contiguous: convert it with numpy.ascontiguousarray()",
+        ));
+    }
+    arr.as_slice().map_err(Into::into)
+}
 
 fn to_numpy_1d<T: numpy::Element>(py: Python<'_>, vec: Vec<T>) -> Bound<'_, PyArray1<T>> {
     PyArray::from_vec(py, vec)

--- a/pytucanos/src/mesh.rs
+++ b/pytucanos/src/mesh.rs
@@ -181,9 +181,9 @@ macro_rules! impl_mesh {
                 validate_faces_shape::<$cell<Idx>>(faces.shape())?;
                 validate_tags_length(ftags.shape()[0], faces.shape()[0], "ftags")?;
 
-                let coords_iter = coords_to_vertices::<$dim>(coords.as_slice()?);
-                let elems_iter = slice_to_simplex(elems.as_slice()?)?;
-                let faces_iter = slice_to_simplex(faces.as_slice()?)?;
+                let coords_iter = coords_to_vertices::<$dim>($crate::as_c_slice(&coords)?);
+                let elems_iter = slice_to_simplex($crate::as_c_slice(&elems)?)?;
+                let faces_iter = slice_to_simplex($crate::as_c_slice(&faces)?)?;
 
                 let mut res = GenericMesh::empty();
                 res.add_verts(coords_iter);
@@ -263,14 +263,14 @@ macro_rules! impl_mesh {
                 if let Some(data) = vert_data.as_ref() {
                     for (name, arr) in data.iter() {
                         let n = arr.shape()[1];
-                        let arr = arr.as_slice()?;
+                        let arr = $crate::as_c_slice(arr)?;
                         writer.add_point_data(name, n, arr.iter().copied())
                     }
                 }
                 if let Some(data) = elem_data.as_ref() {
                     for (name, arr) in data.iter() {
                         let n = arr.shape()[1];
-                        let arr = arr.as_slice()?;
+                        let arr = $crate::as_c_slice(arr)?;
                         writer.add_cell_data(name, n, arr.iter().copied())
                     }
                 }
@@ -347,7 +347,7 @@ macro_rules! impl_mesh {
             /// Add vertices
             pub fn add_verts(&mut self, coords: PyReadonlyArray2<f64>) -> PyResult<()> {
                 validate_coords_shape::<$dim>(coords.shape())?;
-                let coords_iter = coords_to_vertices::<$dim>(coords.as_slice()?);
+                let coords_iter = coords_to_vertices::<$dim>($crate::as_c_slice(&coords)?);
                 self.0.add_verts(coords_iter);
                 Ok(())
             }
@@ -364,7 +364,7 @@ macro_rules! impl_mesh {
                 ftags: PyReadonlyArray1<Tag>,
             ) -> PyResult<()> {
                 validate_faces_shape::<$cell<Idx>>(faces.shape())?;
-                let faces_iter = slice_to_simplex(faces.as_slice()?)?;
+                let faces_iter = slice_to_simplex($crate::as_c_slice(&faces)?)?;
                 self.0
                     .add_faces(faces_iter, ftags.as_slice()?.iter().copied());
                 Ok(())
@@ -377,7 +377,7 @@ macro_rules! impl_mesh {
                 etags: PyReadonlyArray1<Tag>,
             ) -> PyResult<()> {
                 validate_elems_shape::<$cell<Idx>>(elems.shape())?;
-                let elems_iter = slice_to_simplex(elems.as_slice()?)?;
+                let elems_iter = slice_to_simplex($crate::as_c_slice(&elems)?)?;
                 self.0
                     .add_elems(elems_iter, etags.as_slice()?.iter().copied());
                 Ok(())
@@ -394,7 +394,9 @@ macro_rules! impl_mesh {
                     return Err(PyValueError::new_err("Invalid dimension 1 for elems"));
                 }
                 self.0.add_quadrangles(
-                    elems.as_slice()?.chunks(4).map(|x| x.try_into().unwrap()),
+                    $crate::as_c_slice(&elems)?
+                        .chunks(4)
+                        .map(|x| x.try_into().unwrap()),
                     etags.as_slice()?.iter().cloned(),
                 );
                 Ok(())
@@ -411,7 +413,9 @@ macro_rules! impl_mesh {
                     return Err(PyValueError::new_err("Invalid dimension 1 for elems"));
                 }
                 self.0.add_pyramids(
-                    elems.as_slice()?.chunks(5).map(|x| x.try_into().unwrap()),
+                    $crate::as_c_slice(&elems)?
+                        .chunks(5)
+                        .map(|x| x.try_into().unwrap()),
                     etags.as_slice()?.iter().cloned(),
                 );
                 Ok(())
@@ -428,7 +432,9 @@ macro_rules! impl_mesh {
                     return Err(PyValueError::new_err("Invalid dimension 1 for elems"));
                 }
                 self.0.add_prisms(
-                    elems.as_slice()?.chunks(6).map(|x| x.try_into().unwrap()),
+                    $crate::as_c_slice(&elems)?
+                        .chunks(6)
+                        .map(|x| x.try_into().unwrap()),
                     etags.as_slice()?.iter().cloned(),
                 );
                 Ok(())
@@ -446,7 +452,9 @@ macro_rules! impl_mesh {
                     return Err(PyValueError::new_err("Invalid dimension 1 for elems"));
                 }
                 let ids = self.0.add_hexahedra(
-                    elems.as_slice()?.chunks(8).map(|x| x.try_into().unwrap()),
+                    $crate::as_c_slice(&elems)?
+                        .chunks(8)
+                        .map(|x| x.try_into().unwrap()),
                     etags.as_slice()?.iter().cloned(),
                 );
                 Ok(PyArray1::from_vec(py, ids))
@@ -568,9 +576,8 @@ macro_rules! impl_mesh {
                 let interp = Interpolator::new(&self.0, method);
 
                 let res = interp.interpolate(
-                    data.as_slice()?,
-                    verts
-                        .as_slice()?
+                    $crate::as_c_slice(&data)?,
+                    $crate::as_c_slice(&verts)?
                         .chunks($dim)
                         .map(|x| Vertex::<$dim>::from_column_slice(x)),
                 );
@@ -640,7 +647,7 @@ macro_rules! impl_mesh {
                     _ => unreachable!("Invalid order {order}"),
                 };
 
-                let res = self.0.smooth(method, arr.as_slice()?);
+                let res = self.0.smooth(method, $crate::as_c_slice(&arr)?);
                 PyArray::from_vec(py, res).reshape([self.0.n_verts(), 1])
             }
 
@@ -666,7 +673,7 @@ macro_rules! impl_mesh {
                     2 => GradientMethod::LinearLeastSquares(weight_exp),
                     _ => unreachable!("Invalid order {order}"),
                 };
-                let res = self.0.gradient(method, arr.as_slice()?);
+                let res = self.0.gradient(method, $crate::as_c_slice(&arr)?);
                 PyArray::from_vec(py, res).reshape([self.0.n_verts(), $dim])
             }
 
@@ -688,7 +695,7 @@ macro_rules! impl_mesh {
 
                 let res = self.0.hessian(
                     GradientMethod::QuadraticLeastSquares(weight_exp),
-                    arr.as_slice()?,
+                    $crate::as_c_slice(&arr)?,
                 );
 
                 PyArray::from_vec(py, res).reshape([self.0.n_verts(), $dim * ($dim + 1) / 2])
@@ -711,7 +718,7 @@ macro_rules! impl_mesh {
 
                 let res = self
                     .0
-                    .hessian(GradientMethod::L2Projection, arr.as_slice()?);
+                    .hessian(GradientMethod::L2Projection, $crate::as_c_slice(&arr)?);
 
                 PyArray::from_vec(py, res).reshape([self.0.n_verts(), $dim * ($dim + 1) / 2])
             }
@@ -727,7 +734,9 @@ macro_rules! impl_mesh {
                     return Err(PyValueError::new_err("Invalid dimension 0"));
                 }
                 let v2e = self.0.vertex_to_elems();
-                let res = self.0.elem_data_to_vertex_data(&v2e, arr.as_slice()?);
+                let res = self
+                    .0
+                    .elem_data_to_vertex_data(&v2e, $crate::as_c_slice(&arr)?);
                 PyArray::from_vec(py, res).reshape([self.0.n_verts(), arr.shape()[1]])
             }
 
@@ -741,7 +750,7 @@ macro_rules! impl_mesh {
                 if arr.shape()[0] != self.0.n_verts() as usize {
                     return Err(PyValueError::new_err("Invalid dimension 0"));
                 }
-                let res = self.0.vertex_data_to_elem_data(arr.as_slice()?);
+                let res = self.0.vertex_data_to_elem_data($crate::as_c_slice(&arr)?);
                 PyArray::from_vec(py, res).reshape([self.0.n_elems(), arr.shape()[1]])
             }
 

--- a/pytucanos/src/metric.rs
+++ b/pytucanos/src/metric.rs
@@ -30,8 +30,8 @@ pub fn intersect_aniso_metric_3d<'py>(
         ));
     }
 
-    let m1 = m1.as_slice()?;
-    let m2 = m2.as_slice()?;
+    let m1 = crate::as_c_slice(&m1)?;
+    let m2 = crate::as_c_slice(&m2)?;
 
     let m = m1
         .chunks(6)
@@ -190,8 +190,8 @@ pub fn intersect_aniso_metric_2d<'py>(
         ));
     }
 
-    let m1 = m1.as_slice()?;
-    let m2 = m2.as_slice()?;
+    let m1 = crate::as_c_slice(&m1)?;
+    let m2 = crate::as_c_slice(&m2)?;
 
     let m = m1
         .chunks(3)

--- a/pytucanos/src/parallel.rs
+++ b/pytucanos/src/parallel.rs
@@ -117,7 +117,7 @@ macro_rules! create_parallel_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice()?;
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -155,7 +155,7 @@ macro_rules! create_parallel_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice()?;
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))

--- a/pytucanos/src/poly.rs
+++ b/pytucanos/src/poly.rs
@@ -57,7 +57,7 @@ macro_rules! create_poly_mesh {
                     PyPolyMeshType::Polyhedra => PolyMeshType::Polyhedra,
                 };
 
-                let coords = coords.as_slice()?;
+                let coords = crate::as_c_slice(&coords)?;
                 let coords = coords
                     .chunks($dim)
                     .map(|p| {

--- a/pytucanos/src/remesher.rs
+++ b/pytucanos/src/remesher.rs
@@ -408,7 +408,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice()?;
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -443,7 +443,7 @@ macro_rules! create_remesher {
                 }
 
                 let mut res = Vec::with_capacity(m.shape()[0] * m.shape()[1]);
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let mut m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -492,7 +492,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -500,14 +500,14 @@ macro_rules! create_remesher {
                 let mut m = MetricField::new(&mesh.0, m);
 
                 let res = if let Some(fixed_m) = fixed_m {
-                    let fixed_m = fixed_m.as_slice().unwrap();
+                    let fixed_m = crate::as_c_slice(&fixed_m)?;
                     let fixed_m: Vec<_> = fixed_m
                         .chunks($metric::N)
                         .map(|x| $metric::from_slice(x))
                         .collect();
                     let fixed_m = MetricField::new(&mesh.0, fixed_m);
                     if let Some(implied_m) = implied_m {
-                        let implied_m = implied_m.as_slice().unwrap();
+                        let implied_m = crate::as_c_slice(&implied_m)?;
                         let implied_m: Vec<_> = implied_m
                             .chunks($metric::N)
                             .map(|x| $metric::from_slice(x))
@@ -533,7 +533,7 @@ macro_rules! create_remesher {
                         )
                     }
                 } else if let Some(implied_m) = implied_m {
-                    let implied_m = implied_m.as_slice().unwrap();
+                    let implied_m = crate::as_c_slice(&implied_m)?;
                     let implied_m: Vec<_> = implied_m
                         .chunks($metric::N)
                         .map(|x| $metric::from_slice(x))
@@ -582,7 +582,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -619,7 +619,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let  m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -652,7 +652,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -679,7 +679,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
@@ -715,10 +715,10 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice().unwrap();
+                let m = crate::as_c_slice(&m)?;
                 let m = m.chunks($metric::N).map(|x| $metric::from_slice(x));
 
-                let m_other = m_other.as_slice().unwrap();
+                let m_other = crate::as_c_slice(&m_other)?;
                 let m_other = m_other.chunks($metric::N).map(|x| $metric::from_slice(x));
 
                 let mut res =
@@ -738,14 +738,14 @@ macro_rules! create_remesher {
                 _cls: &Bound<'_, PyType>,
                 mesh: &$mesh,
                 m: PyReadonlyArray2<f64>,
-            ) -> (f64, f64, f64, f64) {
-                let m = m.as_slice().unwrap();
+            ) -> PyResult<(f64, f64, f64, f64)> {
+                let m = crate::as_c_slice(&m)?;
                 let m = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))
                     .collect::<Vec<_>>();
                 let m = MetricField::new(&mesh.0, m);
-                m.info()
+                Ok(m.info())
             }
 
             /// Check that the mesh is valid
@@ -836,7 +836,7 @@ macro_rules! create_remesher {
                     return Err(PyValueError::new_err("Invalid dimension 1"));
                 }
 
-                let m = m.as_slice()?;
+                let m = crate::as_c_slice(&m)?;
                 let m: Vec<_> = m
                     .chunks($metric::N)
                     .map(|x| $metric::from_slice(x))


### PR DESCRIPTION
## Problem

The numpy crate's `as_slice()` accepts any contiguous buffer, including Fortran-ordered arrays (it checks `NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS`), but every place pytucanos calls it reads the flat slice assuming row-major order. Passing an F-ordered array therefore silently scrambles the data, with no error.

This is easy to hit from Python: fancy indexing along axis 1 returns an F-ordered copy. For example, flipping triangle orientations before building a mesh:

```python
coords = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
tris = np.array([[0, 1, 2], [1, 3, 2]], dtype=Idx)[:, [1, 0, 2]]  # F-ordered copy
m = BoundaryMesh3d(coords, tris, ...)
m.get_elems()
# array([[1, 3, 0],
#        [1, 2, 2]])   <- transposed buffer: degenerate garbage, no error
```

A mesh built this way fails much later (e.g. `fix()` panics with `Non-manifold mesh / invalid orientation`), which makes the root cause very hard to trace.

## Fix

- Add an `as_c_slice()` helper that raises `ValueError: array is not C-contiguous: convert it with numpy.ascontiguousarray()` unless the array is C-contiguous, and use it for every multi-dimensional array input (mesh constructors, `add_*`, interpolation, smoothing/gradient/hessian, VTK export data, metrics, remesher, parallel remesher, poly and extruded meshes). 1D contiguous arrays carry both contiguity flags, so their behaviour is unchanged.
- Replace the `as_slice().unwrap()` calls in the remesher metric methods with error propagation; `metric_info` now returns `PyResult`, which is transparent on the Python side.
- Regression test: `test_init_f_order_fail` checks that F-ordered `elems`/`coords` are rejected and that `np.ascontiguousarray` of the same data round-trips correctly.

`cargo fmt`, `cargo clippy`, `ruff` and `python -m unittest discover` (49 tests) pass locally.