### PR TITLE
feat(vtkio): extract VTK writer into generic crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["tucanos", "pytucanos", "tmesh", "tucanos-ffi", "tucanos-ffi-test"]
+members = ["tucanos", "pytucanos", "tmesh", "tucanos-ffi", "tucanos-ffi-test", "tucanos-vtkio"]
 default-members = ["tucanos", "tmesh"]
 resolver = "3"
 

--- a/tmesh/Cargo.toml
+++ b/tmesh/Cargo.toml
@@ -22,6 +22,7 @@ argmin = { git = "https://github.com/tucanos/argmin.git", tag = "tucanos-0.4.0",
 argmin-math = { git = "https://github.com/tucanos/argmin.git", tag = "tucanos-0.4.0", features = ["nalgebra_latest",], optional=true }
 argmin-observer-slog = {version = "0.2.0", optional=true}
 libm.workspace = true
+tucanos-vtkio = { path = "../tucanos-vtkio" }
 
 [features]
 32bit-tags = []

--- a/tmesh/src/io/vtu_output.rs
+++ b/tmesh/src/io/vtu_output.rs
@@ -1,250 +1,40 @@
-use crate::{
-    Tag, Vertex,
-    dual::{PolyMesh, PolyMeshType, merge_polylines},
-    extruded::ExtrudedMesh2d,
-    mesh::{Idx, Mesh, Prism, Simplex},
-};
-use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::{
-    io::{BufWriter, Result, Write},
+    io::{BufWriter, Result},
     path::Path,
 };
 
+use crate::{
+    Vertex,
+    dual::{PolyMesh, PolyMeshType, merge_polylines},
+    extruded::ExtrudedMesh2d,
+    mesh::{Idx, Mesh, Simplex},
+};
+use rustc_hash::{FxBuildHasher, FxHashSet};
+use tucanos_vtkio::{Scalar, UnstructuredGridWriter};
+
+fn add_points<'a, const D: usize, IT>(writer: &mut UnstructuredGridWriter<'a>, verts: IT)
+where
+    IT: Iterator<Item = Vertex<D>> + 'a,
+{
+    match D {
+        3 => writer.add_points(verts.map(|v| v.data.0[0])),
+        2 => writer.add_points(verts.map(|x| [x[0], x[1], 0.0])),
+        _ => unimplemented!(),
+    }
+}
 /// VTU file writer
-pub struct VTUFile {
-    number_of_points: usize,
-    number_of_cells: usize,
-    points: DataArray,
-    cells: Vec<DataArray>,
-    cell_data: Vec<DataArray>,
-    point_data: Vec<DataArray>,
-}
+pub struct VTUFile<'a>(UnstructuredGridWriter<'a>);
 
-#[derive(Clone, Copy)]
-enum Version {
-    /// File version for best compatibility
-    V0_1,
-    /// File version only compatible with VTK >= 9.4, Paraview >= 6
-    #[allow(dead_code)]
-    V2_3,
-}
-
-impl VTUFile {
+impl<'a> VTUFile<'a> {
     /// Create a vtu Mesh writer
-    pub fn from_mesh<const D: usize, M: Mesh<D>>(mesh: &M) -> Self {
-        Self {
-            number_of_points: mesh.n_verts(),
-            number_of_cells: mesh.n_elems(),
-            points: DataArray::from_verts(mesh.verts()),
-            cells: DataArray::from_elems(mesh),
-            cell_data: vec![DataArray::from_etags(mesh.etags())],
-            point_data: vec![],
-        }
-    }
-
-    /// Create a vtu ExtrudedMesh2d writer
-    #[must_use]
-    pub fn from_extruded_mesh(mesh: &ExtrudedMesh2d<impl Idx>) -> Self {
-        Self {
-            number_of_points: mesh.n_verts(),
-            number_of_cells: mesh.n_prisms(),
-            points: DataArray::from_verts(mesh.verts()),
-            cells: DataArray::from_prisms(mesh.prisms()),
-            cell_data: vec![DataArray::from_etags(mesh.prism_tags())],
-            point_data: vec![],
-        }
-    }
-
-    /// Create a vtu PolyMesh writer
-    pub fn from_poly_mesh<const D: usize, M: PolyMesh<D>>(mesh: &M) -> Self {
-        Self {
-            number_of_points: mesh.n_verts(),
-            number_of_cells: mesh.n_elems(),
-            points: DataArray::from_verts(mesh.verts()),
-            cells: DataArray::from_poly(mesh, Version::V0_1),
-            cell_data: vec![DataArray::from_etags(mesh.etags())],
-            point_data: vec![],
-        }
-    }
-
-    /// Add cell data
-    pub fn add_cell_data<T: ScalarData>(
-        &mut self,
-        name: &str,
-        number_of_components: usize,
-        data: impl IntoIterator<Item = T>,
-    ) {
-        self.cell_data
-            .push(DataArray::new(name, number_of_components, data));
-    }
-
-    /// Add point data
-    pub fn add_point_data<T: ScalarData>(
-        &mut self,
-        name: &str,
-        number_of_components: usize,
-        data: impl IntoIterator<Item = T>,
-    ) {
-        self.point_data
-            .push(DataArray::new(name, number_of_components, data));
-    }
-
-    /// Write the file
-    pub fn export<P: AsRef<Path>>(&self, file_name: P) -> Result<()> {
-        let f = std::fs::File::create(file_name)?;
-        let mut writer = BufWriter::new(f);
-        writeln!(
-            writer,
-            concat!(
-                r#"<VTKFile type="UnstructuredGrid" version="1.0" byte_order="LittleEndian""#,
-                r#" header_type="UInt64">
-  <UnstructuredGrid>
-    <Piece NumberOfPoints="{}" NumberOfCells="{}">"#
-            ),
-            self.number_of_points, self.number_of_cells
-        )?;
-        let mut offset = 0;
-        let mut write_section = |name: &str, arrays: &[DataArray]| -> Result<()> {
-            if arrays.is_empty() {
-                return Ok(());
-            }
-            writeln!(writer, "      <{name}>")?;
-            for a in arrays {
-                writeln!(writer, "        {}", a.to_xml_tag(offset))?;
-                offset += size_of::<u64>() + a.data.len();
-            }
-            writeln!(writer, "      </{name}>")
-        };
-
-        write_section("Points", std::slice::from_ref(&self.points))?;
-        write_section("Cells", &self.cells)?;
-        write_section("CellData", &self.cell_data)?;
-        write_section("PointData", &self.point_data)?;
-        write!(
-            writer,
-            "    </Piece>\n  </UnstructuredGrid>\n  <AppendedData encoding=\"raw\">\n   _"
-        )?;
-        for a in std::iter::once(&self.points)
-            .chain(&self.cells)
-            .chain(&self.cell_data)
-            .chain(&self.point_data)
-        {
-            a.write(&mut writer)?;
-        }
-        Ok(())
-    }
-}
-
-struct DataArray {
-    data_type: String,
-    name: String,
-    number_of_components: usize,
-    data: Vec<u8>,
-}
-
-pub trait ScalarData: Sized {
-    const TYPE_NAME: &'static str;
-    type Bytes: IntoIterator<Item = u8>;
-    fn to_le_bytes(self) -> Self::Bytes;
-}
-
-impl ScalarData for f64 {
-    const TYPE_NAME: &'static str = "Float64";
-    type Bytes = [u8; 8];
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl ScalarData for usize {
-    const TYPE_NAME: &'static str = "UInt64";
-    type Bytes = [u8; 8];
-
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-impl ScalarData for i64 {
-    const TYPE_NAME: &'static str = "Int64";
-    type Bytes = [u8; 8];
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-impl ScalarData for i32 {
-    const TYPE_NAME: &'static str = "Int32";
-    type Bytes = [u8; 4];
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-impl ScalarData for i16 {
-    const TYPE_NAME: &'static str = "Int16";
-    type Bytes = [u8; 2];
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-impl ScalarData for u8 {
-    const TYPE_NAME: &'static str = "UInt8";
-    type Bytes = [Self; 1];
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-impl ScalarData for i8 {
-    const TYPE_NAME: &'static str = "Int8";
-    type Bytes = [u8; 1];
-    fn to_le_bytes(self) -> Self::Bytes {
-        self.to_le_bytes()
-    }
-}
-
-impl DataArray {
-    pub fn new<T>(
-        name: &str,
-        number_of_components: usize,
-        data: impl IntoIterator<Item = T>,
-    ) -> Self
-    where
-        T: ScalarData,
-    {
-        Self {
-            data_type: T::TYPE_NAME.to_string(),
-            name: name.to_string(),
-            number_of_components,
-            data: data.into_iter().flat_map(T::to_le_bytes).collect(),
-        }
-    }
-    pub fn from_etags(data: impl ExactSizeIterator<Item = Tag>) -> Self {
-        Self::new("tags", 1, data)
-    }
-    pub fn from_prisms<'a>(
-        prisms: impl ExactSizeIterator<Item = &'a Prism<impl Idx>>,
-    ) -> Vec<Self> {
-        let n = prisms.len();
-        let connectivity = Self::new("connectivity", 1, prisms.copied().flatten());
-        let data = (0..n).map(|i| 6 * (i + 1));
-        let offsets = Self::new("offsets", 1, data);
-        let data = (0..n).map(|_i| 13_u8);
-        let types = Self::new("types", 1, data);
-        vec![connectivity, offsets, types]
-    }
-
-    pub fn from_elems<const D: usize, M: Mesh<D>>(mesh: &M) -> Vec<Self> {
+    pub fn from_mesh<const D: usize, M: Mesh<D>>(mesh: &'a M) -> Self {
+        let mut w = UnstructuredGridWriter::default();
+        w.set_num_points(mesh.n_verts());
         let n = mesh.n_elems();
-
-        let connectivity = Self::new("connectivity", 1, mesh.elems().flatten());
-
-        let data = (0..n).map(|i| <M::C as Simplex>::N_VERTS * (i + 1));
-        let offsets = Self::new("offsets", 1, data);
-
+        w.set_num_cells(n);
+        add_points(&mut w, mesh.verts());
+        w.add_cell_data("tags", 1, mesh.etags());
+        let offsets = (0..n).map(|i| <M::C as Simplex>::N_VERTS * (i + 1));
         let cell_type: u8 = match <M::C as Simplex>::order() {
             1 => match <M::C as Simplex>::N_VERTS {
                 4 => 10,
@@ -260,39 +50,71 @@ impl DataArray {
             },
             _ => unimplemented!(),
         };
-
-        let data = (0..n).map(|_i| cell_type);
-        let types = Self::new("types", 1, data);
-
-        vec![connectivity, offsets, types]
+        let types = (0..n).map(move |_i| cell_type);
+        w.add_cells(
+            <M::C as Simplex>::N_VERTS * n,
+            mesh.elems().flatten(),
+            offsets,
+            types,
+        );
+        Self(w)
     }
 
-    pub fn from_verts<const D: usize>(data: impl ExactSizeIterator<Item = Vertex<D>>) -> Self {
-        let name = "Points";
-        match D {
-            3 => Self::new(name, 3, data.flat_map(|x| [x[0], x[1], x[2]])),
-            2 => Self::new(name, 3, data.flat_map(|x| [x[0], x[1], 0.0])),
-            _ => unimplemented!(),
+    /// Create a vtu ExtrudedMesh2d writer
+    #[must_use]
+    pub fn from_extruded_mesh(mesh: &'a ExtrudedMesh2d<impl Idx>) -> Self {
+        let mut w = UnstructuredGridWriter::default();
+        w.set_num_points(mesh.n_verts());
+        let n = mesh.n_prisms();
+        w.set_num_cells(n);
+        add_points(&mut w, mesh.verts());
+        w.add_cell_data("tags", 1, mesh.prism_tags());
+        let prisms = mesh.prisms();
+        let connectivity = prisms.copied().flatten();
+        let offsets = (0..n).map(|i| 6 * (i + 1));
+        let types = (0..n).map(|_i| 13_u8);
+        w.add_cells(6 * n, connectivity, offsets, types);
+        Self(w)
+    }
+
+    /// Create a vtu PolyMesh writer
+    pub fn from_poly_mesh<const D: usize, M: PolyMesh<D>>(mesh: &'a M) -> Self {
+        let mut w = UnstructuredGridWriter::default();
+        w.set_num_points(mesh.n_verts());
+        w.set_num_cells(mesh.n_elems());
+        add_points(&mut w, mesh.verts());
+        w.add_cell_data("tags", 1, mesh.etags());
+        let (connectivity, offsets) = Self::poly_connectivity(mesh);
+        let n = mesh.n_elems();
+        let cell_type: u8 = match mesh.poly_type() {
+            PolyMeshType::Polylines => 4,
+            PolyMeshType::Polygons => 7,
+            PolyMeshType::Polyhedra => 42,
+        };
+        let types = (0..n).map(move |_| cell_type);
+        w.add_cells(connectivity.len(), connectivity, offsets, types);
+        if matches!(mesh.poly_type(), PolyMeshType::Polyhedra) {
+            let mut faces = Vec::new();
+            let mut faceoffsets = Vec::new();
+
+            for e in mesh.elems() {
+                faces.push(e.len());
+                for (i_face, orient) in e {
+                    let mut f = mesh.face(i_face).collect::<Vec<_>>();
+                    if !orient {
+                        f.reverse();
+                    }
+                    faces.push(f.len());
+                    faces.extend_from_slice(&f);
+                }
+                faceoffsets.push(faces.len());
+            }
+            w.add_polyhedron_faces(faces.len(), faces, faceoffsets.len(), faceoffsets);
         }
+        Self(w)
     }
 
-    /// Generates the XML header tag for the Appended mode.
-    pub fn to_xml_tag(&self, offset: usize) -> String {
-        format!(
-            concat!(
-                r#"<DataArray type="{}" Name="{}" NumberOfComponents="{}" "#,
-                r#"format="appended" offset="{}"/>"#
-            ),
-            self.data_type, self.name, self.number_of_components, offset
-        )
-    }
-
-    pub fn write<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.data.len().to_le_bytes())?;
-        writer.write_all(&self.data)
-    }
-
-    fn poly_connectivity<const D: usize, M: PolyMesh<D>>(mesh: &M) -> (Self, Self) {
+    fn poly_connectivity<const D: usize, M: PolyMesh<D>>(mesh: &M) -> (Vec<usize>, Vec<usize>) {
         let mut connectivity = Vec::new();
         let mut offsets = Vec::new();
         for e in mesh.elems() {
@@ -337,78 +159,29 @@ impl DataArray {
             }
             offsets.push(connectivity.len());
         }
-        let connectivity = Self::new("connectivity", 1, connectivity);
-        let offsets = Self::new("offsets", 1, offsets);
         (connectivity, offsets)
     }
 
-    pub fn from_poly<const D: usize, M: PolyMesh<D>>(mesh: &M, version: Version) -> Vec<Self> {
-        let n = mesh.n_elems();
-        let (connectivity, offsets) = Self::poly_connectivity(mesh);
-        let cell_type: u8 = match mesh.poly_type() {
-            PolyMeshType::Polylines => 4,
-            PolyMeshType::Polygons => 7,
-            PolyMeshType::Polyhedra => 42,
-        };
+    pub fn export<P: AsRef<Path>>(self, file_name: P) -> Result<()> {
+        let f = std::fs::File::create(file_name)?;
+        let mut writer = BufWriter::new(f);
+        self.0.write(&mut writer)
+    }
 
-        let types = Self::new("types", 1, (0..n).map(|_| cell_type));
+    pub fn add_cell_data<T, IT>(&mut self, label: &str, num_components: usize, values: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        self.0.add_cell_data(label, num_components, values);
+    }
 
-        let mut data_array = vec![connectivity, offsets, types];
-
-        if matches!(mesh.poly_type(), PolyMeshType::Polyhedra) {
-            match version {
-                Version::V0_1 => {
-                    let mut faces = Vec::new();
-                    let mut faceoffsets = Vec::new();
-
-                    for e in mesh.elems() {
-                        faces.push(e.len());
-                        for (i_face, orient) in e {
-                            let mut f = mesh.face(i_face).collect::<Vec<_>>();
-                            if !orient {
-                                f.reverse();
-                            }
-                            faces.push(f.len());
-                            faces.extend_from_slice(&f);
-                        }
-                        faceoffsets.push(faces.len());
-                    }
-
-                    data_array.push(Self::new("faces", 1, faces));
-                    data_array.push(Self::new("faceoffsets", 1, faceoffsets));
-                }
-                Version::V2_3 => {
-                    let mut polyhedron_offsets = Vec::with_capacity(n);
-                    let mut offset = 0;
-                    for e in mesh.elems() {
-                        offset += e.len();
-                        polyhedron_offsets.push(offset);
-                    }
-                    let polyhedron_to_faces = Self::new(
-                        "polyhedron_to_faces",
-                        1,
-                        mesh.elems().flat_map(|x| x.map(|(x, _)| x)),
-                    );
-
-                    let polyhedron_offsets = Self::new("polyhedron_offsets", 1, polyhedron_offsets);
-
-                    let n = mesh.n_faces();
-                    let mut face_offsets = Vec::with_capacity(n);
-                    let mut offset = 0;
-                    for e in mesh.faces() {
-                        offset += e.len();
-                        face_offsets.push(offset);
-                    }
-
-                    data_array.push(Self::new("face_connectivity", 1, mesh.faces().flatten()));
-                    data_array.push(Self::new("face_offsets", 1, face_offsets));
-                    data_array.push(polyhedron_to_faces);
-                    data_array.push(polyhedron_offsets);
-                }
-            }
-        }
-
-        data_array
+    pub fn add_point_data<T, IT>(&mut self, label: &str, num_components: usize, values: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        self.0.add_point_data(label, num_components, values);
     }
 }
 

--- a/tucanos-vtkio/Cargo.toml
+++ b/tucanos-vtkio/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tucanos-vtkio"
+version.workspace = true
+edition.workspace = true
+description = "Experimental crate for streaming VTK files in appended format on-the-fly without temporary allocations."
+
+[lints]
+workspace = true

--- a/tucanos-vtkio/src/lib.rs
+++ b/tucanos-vtkio/src/lib.rs
@@ -1,0 +1,505 @@
+//! Generic zero-copy serializer for VTK XML files in Appended binary format.
+//!
+//! Provides traits and abstractions for formatting structured or unstructured
+//! geometric primitives into raw binary VTK XML structures (`.vtp`).
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+    mem::size_of,
+};
+
+/// Trait implemented by specific VTK file structures (e.g., `PolyData`, `UnstructuredGrid`)
+trait FileType {
+    const NAME: &str;
+    fn write_piece_attributes(&self, writer: &mut impl Write) -> Result<()>;
+}
+
+#[derive(Default)]
+struct PolyData {
+    number_of_points: usize,
+    number_of_lines: usize,
+}
+
+impl FileType for PolyData {
+    const NAME: &str = "PolyData";
+
+    fn write_piece_attributes(&self, writer: &mut impl Write) -> Result<()> {
+        write!(
+            writer,
+            r#"NumberOfPoints="{}" NumberOfLines="{}""#,
+            self.number_of_points, self.number_of_lines
+        )
+    }
+}
+
+/// Helper to write VTK `PolyData` in appended format.
+#[derive(Default)]
+pub struct PolyDataWriter<'a>(AppendedWriter<'a, PolyData>);
+
+impl<'a> PolyDataWriter<'a> {
+    pub const fn set_num_points(&mut self, n: usize) {
+        self.0.file_type.number_of_points = n;
+    }
+    pub const fn set_num_lines(&mut self, n: usize) {
+        self.0.file_type.number_of_lines = n;
+    }
+    pub fn add_points<T, IT>(&mut self, iterator: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        self.0.sections.insert(
+            "Points",
+            vec![DataArray::new(
+                "Points",
+                3,
+                self.0.file_type.number_of_points,
+                iterator,
+            )],
+        );
+    }
+    pub fn add_lines<T, IT>(&mut self, connectivity: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        let num_lines = self.0.file_type.number_of_lines;
+        self.0.sections.insert(
+            "Lines",
+            vec![
+                DataArray::new("connectivity", 1, num_lines * 2, connectivity),
+                DataArray::new(
+                    "offsets",
+                    1,
+                    num_lines,
+                    (1..=num_lines as u32).map(|x| x * 2),
+                ),
+            ],
+        );
+    }
+    pub fn add_cell_data<T, IT>(&mut self, label: &str, num_components: usize, values: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        let num_cells = self.num_cells();
+        self.0
+            .sections
+            .entry("CellData")
+            .or_default()
+            .push(DataArray::new(label, num_components, num_cells, values));
+    }
+
+    const fn num_cells(&self) -> usize {
+        self.0.file_type.number_of_lines
+    }
+
+    pub fn write(self, writer: &mut impl Write) -> Result<()> {
+        self.0.write(writer)
+    }
+}
+
+#[derive(Default)]
+pub struct UnstructuredGridWriter<'a>(AppendedWriter<'a, UnstructuredGrid>);
+
+impl<'a> UnstructuredGridWriter<'a> {
+    pub const fn set_num_points(&mut self, n: usize) {
+        self.0.file_type.number_of_points = n;
+    }
+    pub const fn set_num_cells(&mut self, n: usize) {
+        self.0.file_type.number_of_cells = n;
+    }
+    pub fn add_points<T, IT>(&mut self, iterator: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        self.0.sections.insert(
+            "Points",
+            vec![DataArray::new(
+                "Points",
+                3,
+                self.0.file_type.number_of_points,
+                iterator,
+            )],
+        );
+    }
+    pub fn add_cells<TC, ITC, TO, ITO, TT, ITT>(
+        &mut self,
+        num_conn: usize,
+        connectivity: ITC,
+        offsets: ITO,
+        types: ITT,
+    ) where
+        TC: Scalar + 'a,
+        TO: Scalar + 'a,
+        TT: Scalar + 'a,
+        ITC: IntoIterator<Item = TC> + 'a,
+        ITO: IntoIterator<Item = TO> + 'a,
+        ITT: IntoIterator<Item = TT> + 'a,
+    {
+        self.0.sections.insert(
+            "Cells",
+            vec![
+                DataArray::new("connectivity", 1, num_conn, connectivity),
+                DataArray::new("offsets", 1, self.0.file_type.number_of_cells, offsets),
+                DataArray::new("types", 1, self.0.file_type.number_of_cells, types),
+            ],
+        );
+    }
+
+    /// Add polyhedron faces. Must be called after `add_cells`.
+    pub fn add_polyhedron_faces<T, ITF, ITO>(
+        &mut self,
+        num_conn: usize,
+        faces: ITF,
+        num_faces: usize,
+        faceoffsets: ITO,
+    ) where
+        T: Scalar + 'a,
+        ITF: IntoIterator<Item = T> + 'a,
+        ITO: IntoIterator<Item = T> + 'a,
+    {
+        let s = self
+            .0
+            .sections
+            .get_mut("Cells")
+            .expect("add_polyhedron_faces must be called after add_cells");
+        s.push(DataArray::new("faces", 1, num_conn, faces));
+        s.push(DataArray::new("faceoffsets", 1, num_faces, faceoffsets));
+    }
+
+    pub fn add_polyhedron_faces_v23<T, ITFC, ITFO>(
+        &mut self,
+        num_conn: usize,
+        face_connectivity: ITFC,
+        num_faces: usize,
+        face_offsets: ITFO,
+    ) where
+        T: Scalar + 'a,
+        ITFC: IntoIterator<Item = T> + 'a,
+        ITFO: IntoIterator<Item = T> + 'a,
+    {
+        self.0.version = "2.3";
+        let s = self
+            .0
+            .sections
+            .get_mut("Cells")
+            .expect("add_polyhedron_faces must be called after add_cells");
+        s.push(DataArray::new(
+            "face_connectivity",
+            1,
+            num_conn,
+            face_connectivity,
+        ));
+        s.push(DataArray::new("face_offsets", 1, num_faces, face_offsets));
+    }
+
+    pub fn add_polyhedron_face_map_v23<T, ITPF, ITPO>(
+        &mut self,
+        num_p_faces: usize,
+        polyhedron_to_faces: ITPF,
+        polyhedron_offsets: ITPO,
+    ) where
+        T: Scalar + 'a,
+        ITPF: IntoIterator<Item = T> + 'a,
+        ITPO: IntoIterator<Item = T> + 'a,
+    {
+        self.0.version = "2.3";
+        let num_cells = self.0.file_type.number_of_cells;
+        let s = self
+            .0
+            .sections
+            .get_mut("Cells")
+            .expect("add_polyhedron_faces must be called after add_cells");
+        s.push(DataArray::new(
+            "polyhedron_to_faces",
+            1,
+            num_p_faces,
+            polyhedron_to_faces,
+        ));
+        s.push(DataArray::new(
+            "polyhedron_offsets",
+            1,
+            num_cells,
+            polyhedron_offsets,
+        ));
+    }
+
+    pub fn add_cell_data<T, IT>(&mut self, label: &str, num_components: usize, values: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        let num_cells = self.num_cells();
+        self.0
+            .sections
+            .entry("CellData")
+            .or_default()
+            .push(DataArray::new(label, num_components, num_cells, values));
+    }
+
+    pub fn add_point_data<T, IT>(&mut self, label: &str, num_components: usize, values: IT)
+    where
+        T: Scalar + 'a,
+        IT: IntoIterator<Item = T> + 'a,
+    {
+        let d = DataArray::new(
+            label,
+            num_components,
+            self.0.file_type.number_of_points,
+            values,
+        );
+        self.0.sections.entry("PointData").or_default().push(d);
+    }
+
+    const fn num_cells(&self) -> usize {
+        self.0.file_type.number_of_cells
+    }
+
+    pub fn write(self, writer: &mut impl Write) -> Result<()> {
+        self.0.write(writer)
+    }
+}
+
+#[derive(Default)]
+pub struct UnstructuredGrid {
+    number_of_points: usize,
+    number_of_cells: usize,
+}
+
+impl FileType for UnstructuredGrid {
+    const NAME: &str = "UnstructuredGrid";
+
+    fn write_piece_attributes(&self, writer: &mut impl Write) -> Result<()> {
+        write!(
+            writer,
+            r#"NumberOfPoints="{}" NumberOfCells="{}""#,
+            self.number_of_points, self.number_of_cells
+        )
+    }
+}
+
+struct AppendedWriter<'a, T: FileType> {
+    file_type: T,
+    version: &'static str,
+    sections: BTreeMap<&'a str, Vec<DataArray<'a>>>,
+}
+
+impl<T: FileType + Default> Default for AppendedWriter<'_, T> {
+    fn default() -> Self {
+        Self {
+            file_type: T::default(),
+            version: "1.0",
+            sections: BTreeMap::default(),
+        }
+    }
+}
+
+impl<'a, T: FileType> AppendedWriter<'a, T> {
+    fn write(mut self, writer: &mut impl Write) -> Result<()> {
+        let typ = T::NAME;
+        let endianness = if cfg!(target_endian = "little") {
+            "LittleEndian"
+        } else {
+            "BigEndian"
+        };
+        write!(
+            writer,
+            r#"<VTKFile type="{typ}" version="{}" byte_order="{endianness}""#,
+            self.version
+        )?;
+        writeln!(
+            writer,
+            r#" header_type="UInt32">
+  <{typ}>
+    <Piece "#
+        )?;
+        self.file_type.write_piece_attributes(writer)?;
+        writeln!(writer, ">")?;
+
+        let mut offset = 0;
+
+        let mut write_section = |name: &str, arrays: &[DataArray<'a>]| -> Result<()> {
+            if !arrays.is_empty() {
+                writeln!(writer, "      <{name}>")?;
+                for a in arrays {
+                    writeln!(writer, "        {}", a.to_xml_tag(offset))?;
+                    offset += size_of::<u32>() + a.byte_len;
+                }
+                writeln!(writer, "      </{name}>")?;
+            }
+            Ok(())
+        };
+
+        for (name, arrays) in &self.sections {
+            write_section(name, arrays)?;
+        }
+        write!(
+            writer,
+            "    </Piece>\n  </{typ}>\n  <AppendedData encoding=\"raw\">\n   _"
+        )?;
+        for section in self.sections.values_mut() {
+            for array in section {
+                array.write(writer)?;
+            }
+        }
+        writeln!(writer, "\n  </AppendedData>\n</VTKFile>")
+    }
+}
+
+struct DataArray<'a> {
+    data_type: &'static str,
+    name: String,
+    number_of_components: usize,
+    byte_len: usize,
+    data: Box<dyn WriteableIter + 'a>,
+}
+
+pub trait Scalar: Sized + Copy {
+    const TYPE_NAME: &'static str;
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()>;
+}
+
+#[cfg(target_pointer_width = "64")]
+impl Scalar for usize {
+    const TYPE_NAME: &'static str = "UInt64";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for i64 {
+    const TYPE_NAME: &'static str = "Int64";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for i32 {
+    const TYPE_NAME: &'static str = "Int32";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for i16 {
+    const TYPE_NAME: &'static str = "Int16";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for u8 {
+    const TYPE_NAME: &'static str = "UInt8";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for i8 {
+    const TYPE_NAME: &'static str = "Int8";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for u32 {
+    const TYPE_NAME: &'static str = "UInt32";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for f32 {
+    const TYPE_NAME: &'static str = "Float32";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl Scalar for f64 {
+    const TYPE_NAME: &'static str = "Float64";
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        writer.write_all(&Self::to_ne_bytes(*self))
+    }
+}
+
+impl<const D: usize> Scalar for [f32; D] {
+    const TYPE_NAME: &'static str = "Float32";
+
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        for val in self {
+            writer.write_all(&val.to_ne_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<const D: usize> Scalar for [f64; D] {
+    const TYPE_NAME: &'static str = "Float64";
+
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        for val in self {
+            writer.write_all(&val.to_ne_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: Scalar> Scalar for &T {
+    const TYPE_NAME: &'static str = T::TYPE_NAME;
+    fn write_ne_bytes(&self, writer: &mut dyn Write) -> Result<()> {
+        (*self).write_ne_bytes(writer)
+    }
+}
+
+trait WriteableIter {
+    fn write_to(&mut self, writer: &mut dyn Write) -> Result<()>;
+}
+
+impl<I, T> WriteableIter for I
+where
+    I: Iterator<Item = T>,
+    T: Scalar,
+{
+    fn write_to(&mut self, writer: &mut dyn Write) -> Result<()> {
+        for item in self {
+            item.write_ne_bytes(writer)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DataArray<'a> {
+    fn new<IT>(name: &str, number_of_components: usize, len: usize, data: IT) -> Self
+    where
+        IT: IntoIterator + 'a,
+        IT::Item: Scalar,
+    {
+        Self {
+            data_type: <IT::Item as Scalar>::TYPE_NAME,
+            name: name.to_string(),
+            number_of_components,
+            data: Box::new(data.into_iter()),
+            byte_len: len * std::mem::size_of::<IT::Item>(),
+        }
+    }
+
+    #[must_use]
+    fn to_xml_tag(&self, offset: usize) -> String {
+        format!(
+            concat!(
+                r#"<DataArray type="{}" Name="{}" NumberOfComponents="{}" "#,
+                r#"format="appended" offset="{}"/>"#
+            ),
+            self.data_type, self.name, self.number_of_components, offset
+        )
+    }
+
+    fn write<W: Write>(&mut self, writer: &mut W) -> Result<()> {
+        let len = self.byte_len as u32;
+        writer.write_all(&len.to_ne_bytes())?;
+        self.data.write_to(writer)
+    }
+}

--- a/tucanos/examples/adapt_ellipse/main.rs
+++ b/tucanos/examples/adapt_ellipse/main.rs
@@ -254,19 +254,18 @@ fn main() -> Result<()> {
 
     // Check the mesh
     mesh.check(&mesh.all_faces())?;
-
-    // Save the input mesh in .vtu format
-    let mut writer = VTUFile::from_mesh(&mesh);
-    writer.add_cell_data("edge_ratio", 1, mesh.edge_length_ratios());
-    writer.add_cell_data("gamma", 1, mesh.elem_gammas());
     let mut skewness = vec![0.0_f64; mesh.n_elems()];
     for (i0, i1, s) in mesh.face_skewnesses(&mesh.all_faces()) {
         skewness[i0] = skewness[i0].max(s);
         skewness[i1] = skewness[i1].max(s);
     }
+    // Save the input mesh in .vtu format
+    let mut writer = VTUFile::from_mesh(&mesh);
+    writer.add_cell_data("edge_ratio", 1, mesh.edge_length_ratios());
+    writer.add_cell_data("gamma", 1, mesh.elem_gammas());
     writer.add_cell_data("skewness", 1, skewness.iter().copied());
-
     writer.export("ellipse.vtu")?;
+
     let bdy = mesh.boundary::<BoundaryMesh3d>().0;
     VTUFile::from_mesh(&bdy).export("ellipse_bdy.vtu")?;
 

--- a/tucanos/src/geometry/curvature.rs
+++ b/tucanos/src/geometry/curvature.rs
@@ -350,14 +350,11 @@ pub fn compute_curvature<const D: usize, M: Mesh<D>>(
 
 pub fn write_curvature<const D: usize, M: Mesh<D>>(mesh: &M, fname: &str) -> Result<()> {
     let (u, v) = compute_curvature(mesh);
-
+    let n = compute_vertex_normals(mesh, VertexNormalWeight::Volume);
     let mut writer = VTUFile::from_mesh(mesh);
     writer.add_cell_data("u", D, u.iter().flatten().copied());
     writer.add_cell_data("v", D, v.as_ref().unwrap().iter().flatten().copied());
-
-    let n = compute_vertex_normals(mesh, VertexNormalWeight::Volume);
     writer.add_point_data("n", D, n.iter().flatten().copied());
-
     writer.export(fname)?;
     Ok(())
 }


### PR DESCRIPTION
Extract the VTU output serializer from `tmesh` into a standalone, zero-copy `tucanos-vtkio` crate to enable direct streaming of VTK files without temporary allocations.