### PR TITLE
pytucanos: add curving submodule for 2D P1<->P2 conversion

### DIFF
--- a/pytucanos/pytucanos/__init__.py
+++ b/pytucanos/pytucanos/__init__.py
@@ -25,6 +25,7 @@ else:
     Idx = np.uint64
 
 from .cgns_io import load_cgns, write_cgns  # noqa: F401
+from .curving import p1_to_p2, p2_to_p1  # noqa: F401
 from .pytucanos import get_thread_affinity, set_thread_affinity  # noqa: F401
 from .pytucanos import (
     LinearGeometry2d,  # noqa: F401
@@ -72,7 +73,6 @@ from .pytucanos import (
     intersect_aniso_metric_3d,  # noqa: F401
     intersect_aniso_metric_2d,  # noqa: F401
 )
-from .curving import p1_to_p2, p2_to_p1  # noqa: F401
 
 
 def autotag(msh, angle_deg):

--- a/pytucanos/pytucanos/__init__.py
+++ b/pytucanos/pytucanos/__init__.py
@@ -72,6 +72,7 @@ from .pytucanos import (
     intersect_aniso_metric_3d,  # noqa: F401
     intersect_aniso_metric_2d,  # noqa: F401
 )
+from .curving import p1_to_p2, p2_to_p1  # noqa: F401
 
 
 def autotag(msh, angle_deg):

--- a/pytucanos/pytucanos/curving.py
+++ b/pytucanos/pytucanos/curving.py
@@ -1,0 +1,213 @@
+"""P1 <-> P2 (isoparametric quadratic) mesh conversion.
+
+Tucanos has no native P2 volume remesher: `Remesher*` only ever adapts
+straight-sided (P1) meshes, even the `*Quadratic` variants (those take a
+*quadratic geometry* as their projection target, not a quadratic mesh).
+`p2_to_p1`/`p1_to_p2` bridge a curved mesh through a P1 remeshing step:
+
+  1. `p2_to_p1`: strip a curved `QuadraticMesh2d` down to its corner-node
+     (P1) skeleton before remeshing. Exact: corner coordinates are
+     unchanged.
+  2. `p1_to_p2`: re-curve the (adapted) P1 mesh by projecting its boundary
+     mid-edge nodes onto the true geometry and propagating that correction
+     to the rest of the mesh with an RBF (`ferreus_rbf`). This is the piece
+     `to_quadratic()` + `geometry.project()` don't provide on their own:
+     `to_quadratic()` only inserts arithmetic midpoints (no curvature), and
+     `project()` only moves boundary vertices; moving the boundary alone
+     would leave a curved skin over an otherwise straight-sided interior,
+     folding elements at any real curvature.
+
+Status: 2D only (`Mesh2d`/`QuadraticMesh2d`), validated on a real
+production h-adaptation loop. 3D (`Mesh3d`/`QuadraticMesh3d`) is not
+implemented here: `bcoords()` for `QuadraticTriangle` has an open
+convergence bug (2-parameter Newton-CG, see `quadratic_triangle.rs`) that
+needs a robust closed-form/guarded solver first, the same class of fix
+already applied to `QuadraticEdge` (used by the 2D path here).
+
+Requires the optional `ferreus_rbf` dependency: `pip install
+pytucanos[curving]`.
+"""
+
+import numpy as np
+
+from . import (
+    Idx,
+    LinearGeometry2d,
+    Mesh2d,
+    QuadraticBoundaryMesh2d,
+    QuadraticGeometry2d,
+    QuadraticMesh2d,
+)
+from .cgns_io import load_cgns
+from .mesh import calibrate_mid_edge_columns
+
+try:
+    from ferreus_rbf import RBFInterpolator
+    from ferreus_rbf.interpolant_config import (
+        FittingAccuracy,
+        FittingAccuracyType,
+        InterpolantSettings,
+        RBFKernelType,
+    )
+
+    HAVE_FERREUS_RBF = True
+except ImportError:
+    HAVE_FERREUS_RBF = False
+
+
+def p2_to_p1(qmesh: QuadraticMesh2d) -> Mesh2d:
+    """
+    Strip a curved `QuadraticMesh2d` (Tri6) to its P1 skeleton (Tri3).
+    Corner coordinates are copied unchanged, so no geometric approximation
+    is involved in this direction. The node array is compacted to only the
+    referenced corner nodes (the now-unused mid-edge nodes are dropped and
+    the rest renumbered contiguously).
+
+    Args:
+        qmesh: curved `QuadraticMesh2d` to strip.
+
+    Returns:
+        New `Mesh2d` with the same corner coordinates, element/boundary tags
+        preserved.
+    """
+    verts = qmesh.get_verts()
+    elems_p1 = np.ascontiguousarray(qmesh.get_elems()[:, :3])
+    faces_p1 = np.ascontiguousarray(qmesh.get_faces()[:, :2])
+
+    used = np.unique(np.concatenate([elems_p1.ravel(), faces_p1.ravel()]))
+    remap = np.full(verts.shape[0], -1, dtype=np.int64)
+    remap[used] = np.arange(used.size)
+
+    return Mesh2d(
+        verts[used],
+        remap[elems_p1].astype(Idx),
+        qmesh.get_etags(),
+        remap[faces_p1].astype(Idx),
+        qmesh.get_ftags(),
+    )
+
+
+def p1_to_p2(
+    mesh: Mesh2d,
+    geom: str | tuple,
+    tag_names: dict,
+    tag_name_map: dict = None,
+    fitting_accuracy=None,
+) -> QuadraticMesh2d:
+    """
+    Re-curve a straight-sided `Mesh2d` to a curved `QuadraticMesh2d`,
+    projecting new boundary mid-edge nodes onto `geom` and RBF-propagating
+    that correction to the whole mesh.
+
+    Only the mesh boundary tags whose *name* also appears in the geometry
+    get projected onto it (matched through `tag_name_map` if given); tags
+    with no match (e.g. a symmetry-plane cap that carries no curvature) are
+    simply left uncorrected. `fitting_accuracy` defaults to 1e-3 relative,
+    much looser than `ferreus_rbf`'s own 1e-6 default: appropriate for a
+    curving correction (not a value the solution otherwise depends on), and
+    needed in practice for the RBF fit to converge in reasonable time at
+    realistic control-point counts.
+
+    Args:
+        mesh: straight-sided `Mesh2d` to curve.
+        geom: path to a CGNS geometry file to project onto, or an
+            already-loaded `(boundary_mesh, tag_names)` pair as returned by
+            `load_cgns` (avoids repeated file I/O, e.g. across several
+            h-adaptation iterations against the same geometry).
+        tag_names: `{tag_value: tag_name}` for `mesh`'s boundary tags.
+        tag_name_map: optional `{mesh_tag_name: geometry_tag_name}` override
+            for cases where the mesh's and the geometry's boundary tag names
+            don't match exactly.
+        fitting_accuracy: optional `ferreus_rbf.FittingAccuracy` override for
+            the RBF fit tolerance; defaults to `FittingAccuracy(1e-3,
+            FittingAccuracyType.Relative)` if None.
+
+    Returns:
+        Curved `QuadraticMesh2d`, all `distortion() > 0`. Its connectivity
+        columns follow whatever order `Mesh2d.to_quadratic()` produced; call
+        `calibrate_mid_edge_columns(mesh.to_quadratic())` if you need to know
+        which column holds which corner pair's mid-edge node (e.g. to export
+        to a mesh format with its own fixed node-slot convention).
+
+    Raises:
+        ImportError: if the optional `ferreus_rbf` dependency isn't
+            installed.
+        RuntimeError: if none of `tag_names` (after `tag_name_map`) match a
+            geometry tag name, or if the RBF-morphed mesh has any
+            folded/invalid element (`distortion() <= 0`).
+        pyo3_runtime.PanicException: `geometry.project()` needs every
+            boundary tag on `mesh` to be defined *somewhere* in `geom`,
+            even tags you don't intend to curve (e.g. a symmetry plane): if
+            `mesh` has a tag entirely absent from `geom`, this panics,
+            uncatchable from Python. That's separate from which tags
+            actually get curved: that part is decided by name-matching
+            (`tag_names`/`tag_name_map` above), and a `geom` patch whose
+            name matches no mesh tag is simply never used as a projection
+            target, which is not an issue.
+    """
+    if not HAVE_FERREUS_RBF:
+        raise ImportError(
+            "p1_to_p2 requires the optional 'ferreus_rbf' dependency: pip install pytucanos[curving]"
+        )
+
+    qm_straight = mesh.to_quadratic()
+    calibrate_mid_edge_columns(
+        qm_straight
+    )  # fail fast on an unexpected to_quadratic() convention
+
+    if isinstance(geom, str):
+        geom_bdy, geom_tag_names = load_cgns(geom)
+    else:
+        geom_bdy, geom_tag_names = geom
+    # A 2nd-order geometry file (BAR_3 here) loads as a QuadraticBoundaryMesh2d
+    # and projects onto the exact curved geometry instead of its linear faceting.
+    if isinstance(geom_bdy, QuadraticBoundaryMesh2d):
+        geometry = QuadraticGeometry2d(geom_bdy)
+    else:
+        geometry = LinearGeometry2d(geom_bdy)
+    projected_all = geometry.project(mesh)
+
+    tag_name_map = tag_name_map or {}
+    geom_names = set(geom_tag_names.keys())
+    geom_tags = [
+        tag
+        for tag, name in tag_names.items()
+        if tag_name_map.get(name, name) in geom_names
+    ]
+    if not geom_tags:
+        raise RuntimeError(
+            f"none of the mesh's boundary tags {tag_names} match a tag name "
+            f"in the geometry ({geom_names}); pass tag_name_map to bridge a naming mismatch"
+        )
+
+    verts_p1 = mesh.get_verts()
+    faces_p1 = mesh.get_faces()
+    ftags_p1 = mesh.get_ftags()
+    boundary_idx = np.unique(faces_p1[np.isin(ftags_p1, geom_tags)])
+    control_pts = verts_p1[boundary_idx]
+    control_disp = projected_all[boundary_idx] - control_pts
+
+    fitting_accuracy = fitting_accuracy or FittingAccuracy(
+        1e-3, FittingAccuracyType.Relative
+    )
+    settings = InterpolantSettings(
+        RBFKernelType.Cubic, fitting_accuracy=fitting_accuracy
+    )
+    rbfi = RBFInterpolator(control_pts, control_disp, settings)
+    verts_p2 = qm_straight.get_verts()
+    new_verts = verts_p2 + rbfi.evaluate(verts_p2)
+
+    qm_deformed = QuadraticMesh2d(
+        new_verts,
+        qm_straight.get_elems(),
+        qm_straight.get_etags(),
+        qm_straight.get_faces(),
+        qm_straight.get_ftags(),
+    )
+    distortion = qm_deformed.distortion()
+    if not np.all(distortion > 0):
+        raise RuntimeError(
+            f"P1->P2 re-curving produced {np.sum(distortion <= 0)} folded/invalid "
+            f"element(s) (min distortion = {distortion.min():.4g})"
+        )
+    return qm_deformed

--- a/pytucanos/pytucanos/curving.py
+++ b/pytucanos/pytucanos/curving.py
@@ -91,7 +91,7 @@ def p1_to_p2(
     mesh: Mesh2d,
     geom: str | tuple,
     tag_names: dict,
-    tag_name_map: dict = None,
+    tag_name_map: dict | None = None,
     fitting_accuracy=None,
 ) -> QuadraticMesh2d:
     """

--- a/pytucanos/pytucanos/curving.py
+++ b/pytucanos/pytucanos/curving.py
@@ -30,16 +30,13 @@ pytucanos[curving]`.
 
 import numpy as np
 
-from . import (
-    Idx,
-    LinearGeometry2d,
-    Mesh2d,
-    QuadraticBoundaryMesh2d,
-    QuadraticGeometry2d,
-    QuadraticMesh2d,
-)
+from . import Idx
 from .cgns_io import load_cgns
 from .mesh import calibrate_mid_edge_columns
+from .pytucanos import LinearGeometry2d, QuadraticGeometry2d
+from .pytucanos import PyMesh2d as Mesh2d
+from .pytucanos import PyQuadraticBoundaryMesh2d as QuadraticBoundaryMesh2d
+from .pytucanos import PyQuadraticMesh2d as QuadraticMesh2d
 
 try:
     from ferreus_rbf import RBFInterpolator

--- a/pytucanos/pytucanos/mesh.py
+++ b/pytucanos/pytucanos/mesh.py
@@ -30,6 +30,52 @@ def edges(els):
     return np.unique(edgs, axis=0)
 
 
+def calibrate_mid_edge_columns(qm, tol=1e-9):
+    """
+    Determine which connectivity column of a `QuadraticMesh2d` (Tri6) holds
+    the mid-edge node for each corner pair.
+
+    `to_quadratic()` does not document which of its extra columns holds
+    which edge's mid-node, so this discovers it empirically: on a
+    straight-sided quadratic mesh (fresh out of `to_quadratic()`, before any
+    curving/projection), every mid-edge node is still the exact arithmetic
+    midpoint of its corner pair.
+
+    Args:
+        qm: `QuadraticMesh2d` produced by `Mesh2d.to_quadratic()` on a
+            straight-sided mesh, so every mid-edge node is still the exact
+            arithmetic midpoint of its corner pair.
+        tol: max allowed distance between a candidate column and the
+            arithmetic midpoint for a match.
+
+    Returns:
+        Dict mapping each corner pair `(0, 1)`, `(1, 2)`, `(2, 0)` to the
+        connectivity column index (3, 4, or 5) holding that edge's mid-node.
+
+    Raises:
+        RuntimeError: if some corner pair can't be matched to any column
+            within `tol` (the mesh isn't actually straight-sided, or
+            `to_quadratic()`'s column convention changed).
+    """
+    elems = qm.get_elems()
+    verts = qm.get_verts()
+    col_for_pair = {}
+    for pair in TRI2EDG:
+        pair = tuple(pair)
+        a, b = pair
+        target = 0.5 * (verts[elems[:, a]] + verts[elems[:, b]])
+        for col in (3, 4, 5):
+            if np.abs(verts[elems[:, col]] - target).max() < tol:
+                col_for_pair[pair] = col
+                break
+        else:
+            raise RuntimeError(
+                f"could not match corner pair {pair} to a mid-edge column"
+            )
+    assert set(col_for_pair.values()) == {3, 4, 5}, col_for_pair
+    return col_for_pair
+
+
 def create_mesh(coords, elems, etags, faces, ftags):
     if coords.shape[1] == 2:
         return Mesh2d(coords, elems, etags, faces, ftags)

--- a/pytucanos/pytucanos/test_curving.py
+++ b/pytucanos/pytucanos/test_curving.py
@@ -1,0 +1,141 @@
+import unittest
+
+import numpy as np
+
+from . import BoundaryMesh2d, Idx, Mesh2d
+from .curving import HAVE_FERREUS_RBF, p1_to_p2, p2_to_p1
+from .mesh import get_square
+
+
+def circle_boundary(center, radius, n, tag=1):
+    theta = 2.0 * np.pi * np.linspace(0, 1, n, endpoint=False)
+    coords = center + radius * np.stack([np.cos(theta), np.sin(theta)], axis=-1)
+    edgs = np.stack([np.arange(n), (np.arange(n) + 1) % n], axis=-1).astype(Idx)
+    etags = np.full(n, tag, dtype=np.int16)
+    return BoundaryMesh2d(
+        coords, edgs, etags, np.zeros([0, 1], dtype=Idx), np.zeros(0, dtype=np.int16)
+    )
+
+
+def square_boundary_geometry(sagitta, n=60):
+    """Boundary geometry matching get_square()'s 4 tags (bottom=1, right=2,
+    top=3, left=4): the bottom edge gently bulges outward by `sagitta`
+    (a scale representative of a CAD-faceting correction, not a large shape
+    change), the other 3 sides are exact straight-line matches of the mesh's
+    own edges, so their projection is a no-op."""
+    x = np.linspace(0.0, 1.0, n + 1)
+    bottom = np.stack([x, -sagitta * 4.0 * x * (1.0 - x)], axis=-1)
+    right = np.array([[1.0, 0.0], [1.0, 1.0]])
+    top = np.array([[1.0, 1.0], [0.0, 1.0]])
+    left = np.array([[0.0, 1.0], [0.0, 0.0]])
+
+    coords = np.vstack([bottom, right, top, left])
+    offsets = np.cumsum(
+        [0, bottom.shape[0], right.shape[0], top.shape[0], left.shape[0]]
+    )
+
+    def segments(lo, hi, tag):
+        idx = np.arange(lo, hi - 1)
+        edgs = np.stack([idx, idx + 1], axis=-1).astype(Idx)
+        etags = np.full(edgs.shape[0], tag, dtype=np.int16)
+        return edgs, etags
+
+    edgs_tags = [
+        segments(offsets[i], offsets[i + 1], tag) for i, tag in enumerate([1, 2, 3, 4])
+    ]
+    edgs = np.vstack([e for e, _ in edgs_tags])
+    etags = np.concatenate([t for _, t in edgs_tags])
+
+    geom_bdy = BoundaryMesh2d(
+        coords, edgs, etags, np.zeros([0, 1], dtype=Idx), np.zeros(0, dtype=np.int16)
+    )
+    geom_tag_names = {"bottom": 1, "right": 2, "top": 3, "left": 4}
+    return geom_bdy, geom_tag_names
+
+
+class TestCurving(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import logging
+
+        logging.disable(logging.CRITICAL)
+
+    def square_mesh_uniform_tag(self):
+        # get_square() tags its 4 boundary edges separately (1..4); use a
+        # single tag for the whole boundary instead, since project() panics
+        # (uncatchable) if any tag *value* present on the mesh has no
+        # counterpart in the geometry, matching how the validated
+        # production case (a geometry file generated to cover every mesh
+        # boundary tag) avoids that constraint.
+        coords, elems, etags, faces, ftags = get_square(two_tags=False)
+        ftags = np.ones_like(ftags)
+        msh = Mesh2d(coords, elems, etags, faces, ftags).split().split()
+        msh.fix()
+        return msh
+
+    def square_mesh_four_tags(self):
+        coords, elems, etags, faces, ftags = get_square(two_tags=False)
+        msh = Mesh2d(coords, elems, etags, faces, ftags).split().split()
+        msh.fix()
+        return msh
+
+    def test_p2_to_p1_roundtrip_is_exact(self):
+        msh = self.square_mesh_uniform_tag()
+        qm = msh.to_quadratic()
+        p1 = p2_to_p1(qm)
+
+        self.assertEqual(p1.n_verts(), msh.n_verts())
+        self.assertEqual(p1.get_elems().shape, msh.get_elems().shape)
+        np.testing.assert_allclose(
+            np.sort(p1.get_verts(), axis=0), np.sort(msh.get_verts(), axis=0)
+        )
+
+    def test_p1_to_p2_no_matching_tag_raises(self):
+        msh = self.square_mesh_uniform_tag()
+        # geometry's tag *value* (1) matches the mesh's, so project() itself
+        # doesn't panic, but its *name* doesn't match tag_names, so no
+        # control points are selected: the intended graceful failure mode.
+        geom_bdy = circle_boundary(np.array([0.5, 0.5]), 0.5**0.5, 20)
+        geom_tag_names = {"unrelated_name": 1}
+        if not HAVE_FERREUS_RBF:
+            with self.assertRaises(ImportError):
+                p1_to_p2(msh, (geom_bdy, geom_tag_names), {1: "circle"})
+            return
+        with self.assertRaises(RuntimeError):
+            p1_to_p2(msh, (geom_bdy, geom_tag_names), {1: "circle"})
+
+    @unittest.skipUnless(HAVE_FERREUS_RBF, "ferreus_rbf not installed")
+    def test_p1_to_p2_gentle_curving_stays_valid(self):
+        msh = self.square_mesh_four_tags()
+        sagitta = 0.02
+        geom = square_boundary_geometry(sagitta)
+        tag_names = {1: "bottom", 2: "right", 3: "top", 4: "left"}
+
+        qm = p1_to_p2(msh, geom, tag_names)
+
+        distortion = qm.distortion()
+        self.assertTrue(
+            np.all(distortion > 0), f"min distortion = {distortion.min():.4g}"
+        )
+
+        # the bottom edge should have bulged outward (y < 0 near its middle;
+        # its endpoints are shared with the untouched left/right edges and
+        # the bulge is 0 there by construction, so only check the extremum)
+        verts = qm.get_verts()
+        faces_p2 = qm.get_faces()
+        ftags_p2 = qm.get_ftags()
+        bottom_y = verts[np.unique(faces_p2[ftags_p2 == 1])][:, 1]
+        self.assertLess(bottom_y.min(), -1e-4)
+        self.assertLess(
+            -bottom_y.min(), 2 * sagitta
+        )  # ...but only by about `sagitta`, not further
+
+        # ...while the other 3 sides, whose geometry exactly matches the
+        # mesh's own straight edges, should barely have moved from their
+        # pre-curving (straight-sided, to_quadratic()-only) position: a
+        # small residual is expected, since the RBF fit is only accurate to
+        # ~1e-3 relative (see p1_to_p2's docstring), not exact.
+        straight_verts = msh.to_quadratic().get_verts()
+        for tag in (2, 3, 4):
+            idx = np.unique(faces_p2[ftags_p2 == tag])
+            np.testing.assert_allclose(verts[idx], straight_verts[idx], atol=5e-4)

--- a/pytucanos/setup.py
+++ b/pytucanos/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     version="0.4.0",
     packages=["pytucanos"],
     install_requires=["numpy", "matplotlib"],
+    extras_require={"curving": ["ferreus_rbf"]},
     rust_extensions=[
         RustExtension(
             "pytucanos.pytucanos",


### PR DESCRIPTION
Add `pytucanos.curving` with `p2_to_p1` (strip a curved `QuadraticMesh2d` to its P1 corner-node skeleton) and `p1_to_p2` (re-curve a P1 mesh by projecting boundary mid-edge nodes onto a geometry and propagating the correction to the whole mesh with an RBF).

- New `pytucanos.curving` submodule (`p1_to_p2`/`p2_to_p1`), mirroring the existing `pytucanos.mesh`/`pytucanos.remesh` pattern.
- New public `calibrate_mid_edge_columns` in `mesh.py`, and 3 new tests in `test_curving.py`.
- `ferreus_rbf` is an optional dependency (`pip install pytucanos[curving]`), lazily imported with a clear `ImportError` if missing.
- 2D only for now (`Mesh2d`/`QuadraticMesh2d`); 3D is out of scope for this PR (blocked on a `QuadraticTriangle::bcoords()` convergence issue, tracked separately).